### PR TITLE
Avoid unnecessary intermediate tar/untar of OCI Image Layout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,15 @@
+name: build
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    
+    - name: Install Opctl
+      run: curl -L https://github.com/opctl/opctl/releases/download/0.1.45/opctl0.1.45.linux.tgz | sudo tar -xzv -C /usr/local/bin
+    
+    - name: Build
+      run: opctl run build

--- a/.opspec/build/op.yml
+++ b/.opspec/build/op.yml
@@ -1,21 +1,10 @@
 name: build
 description: builds the op
-inputs:
-  srcDir:
-    dir:
-      default: .
-outputs:
-  srcDir:
-    dir: {}
-opspec: 0.1.6
 run:
   serial:
     - op:
         ref: test
-        inputs: { srcDir }
     - op:
-        ref: github.com/opspec-pkgs/_.op.bootstrap#2.2.2
+        ref: github.com/opspec-pkgs/_.op.bootstrap#4.0.1
         inputs:
-          srcDir:
-        outputs:
-          srcDir:
+          srcDir: $(../..)

--- a/.opspec/provision-image/op.yml
+++ b/.opspec/provision-image/op.yml
@@ -1,31 +1,29 @@
 name: provision-image
 description: |
-  Provisions image for the op to [opspecpkgs docker hub org](https://hub.docker.com/u/opspecpkgs) w/ name `opspecpkgs/$(opDotYml.name):${opDotYml.version}`.
+  Provisions image for the op to [opspec-pkgs image registry](https://github.com/orgs/opspec-pkgs/packages) w/ name `$(opDotYml.name):${opDotYml.version}`.
   
   > Before first use, a Dockerfile MUST be added to `.opspec/provision-image`
 inputs:
-  dockerUsername:
+  githubUsername:
     string:
       constraints: { minLength: 1 }
-      description: user for logging in to docker hub
-  dockerPassword:
+      description: user for logging in to github
+  githubAccessToken:
     string:
       constraints: { minLength: 1 }
-      description: password for logging in to docker hub
+      description: accessToken for logging in to github
       isSecret: true
-  srcDir:
-    dir:
-      default: .
-opspec: 0.1.6
 run:
   serial:
     - op:
         ref: github.com/opspec-pkgs/yaml.parse#1.0.0
-        inputs: { yaml: $(srcDir/op.yml) }
-        outputs: { opDotYml: result }
+        inputs:
+          yaml: $(../../op.yml)
+        outputs:
+          result: $(opDotYml)
     - container:
         image: { ref: 'alpine:3.6' }
-        cmd: [sh, -ce, 'echo -n opspecpkgs/${opName#*/*/}:$(opDotYml.version) > /imageName']
+        cmd: [sh, -ce, 'echo -n ghcr.io/opspec-pkgs/${opName#*/*/}:$(opDotYml.version) > /imageName']
         envVars:
           opName: $(opDotYml.name)
         files:
@@ -33,7 +31,7 @@ run:
     - op:
         ref: github.com/opspec-pkgs/docker.image.build#2.1.0
         inputs:
-          dockerfile: $(/Dockerfile)
+          dockerfile: $(./Dockerfile)
           imageName:
         outputs: { imageTar }
     - op:
@@ -41,5 +39,6 @@ run:
         inputs:
           imageTar:
           imageName:
-          username: $(dockerUsername)
-          password: $(dockerPassword)
+          registry: ghcr.io
+          username: $(githubUsername)
+          password: $(githubAccessToken)

--- a/.opspec/release/op.yml
+++ b/.opspec/release/op.yml
@@ -5,33 +5,24 @@ inputs:
     string:
       constraints: { minLength: 1 }
       description: user for logging in to github
-  githubPassword:
+  githubAccessToken:
     string:
       constraints: { minLength: 1 }
-      description: password for logging in to github
+      description: accessToken for logging in to github
       isSecret: true
-  srcDir:
-    dir:
-      default: .
-outputs:
-  srcDir:
-    dir: {}
-opspec: 0.1.6
 run:
   serial:
     - op:
         ref: build
-        inputs:
-          srcDir:
-        outputs:
-          srcDir:
     - op:
         ref: github.com/opspec-pkgs/yaml.parse#1.0.0
-        inputs: { yaml: $(srcDir/op.yml) }
-        outputs: { opDotYml: result }
+        inputs:
+          yaml: $(../../op.yml)
+        outputs:
+          result: $(opDotYml)
     - op:
         ref: github.com/opspec-pkgs/git.repo.resolve-commit#1.0.2
-        inputs: { dotGitDir: $(srcDir/.git) }
+        inputs: { dotGitDir: $(../../.git) }
         outputs: { commit: }
     - container:
         image: { ref: 'alpine:3.6' }
@@ -46,7 +37,7 @@ run:
           owner: opspec-pkgs
           repo: $(opRepo)
           loginUsername: $(githubUsername)
-          loginPassword: $(githubPassword)
+          loginPassword: $(githubAccessToken)
           tag: $(opDotYml.version)
           commitish: $(commit)
           name: $(opDotYml.version)

--- a/.opspec/test/op.yml
+++ b/.opspec/test/op.yml
@@ -1,11 +1,7 @@
 name: test
 description: tests the op
-inputs:
-  srcDir:
-    dir:
-      default: .
-opspec: 0.1.6
 run:
   op:
     ref: github.com/opspec-pkgs/opspec.v0.1.6.op.validate#1.0.0
-    inputs: { op: $(srcDir) }
+    inputs:
+      op: $(../..)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes will be documented in this file in accordance with
 
 ## \[Unreleased]
 
+## \[1.3.0] - 2024-05-27
+
+### Updated
+
+- Avoid unnecessary intermediate tar/untar of OCI Image Layout
+
 ## \[1.2.0] - 2020-11-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/opspec-pkgs/opencontainers.image.build.svg?branch=master)](https://travis-ci.org/opspec-pkgs/opencontainers.image.build)
+[![Build Status](https://github.com/opspec-pkgs/opencontainers.image.build/workflows/build/badge.svg?branch=main)](https://github.com/opspec-pkgs/opencontainers.image.build/actions?query=workflow%3Abuild+branch%3Amain)
 
 <img src="icon.svg" alt="icon" height="100px">
 
@@ -6,29 +6,25 @@
 
 Builds an open container initiative (OCI) image
 
-# Format
-
-the op uses [![opspec 0.1.6](https://img.shields.io/badge/opspec-0.1.6-brightgreen.svg?colorA=6b6b6b&colorB=fc16be)](https://opspec.io/0.1.6) definition format
-
 # Example usage
 
-## Install
+## Visualize
 
 ```shell
-opctl op install github.com/opspec-pkgs/opencontainers.image.build#1.2.0
+opctl ui github.com/opspec-pkgs/opencontainers.image.build#1.3.0
 ```
 
 ## Run
 
 ```
-opctl run github.com/opspec-pkgs/opencontainers.image.build#1.2.0
+opctl run github.com/opspec-pkgs/opencontainers.image.build#1.3.0
 ```
 
 ## Compose
 
 ```yaml
 op:
-  ref: github.com/opspec-pkgs/opencontainers.image.build#1.2.0
+  ref: github.com/opspec-pkgs/opencontainers.image.build#1.3.0
   inputs:
     instructions:  # 👈 required; provide a value
   ## uncomment to override defaults
@@ -43,7 +39,7 @@ op:
 # Support
 
 join us on
-[![Slack](https://opctl-slackin.herokuapp.com/badge.svg)](https://opctl-slackin.herokuapp.com/)
+[![Slack](https://img.shields.io/badge/slack-opctl-E01563.svg)](https://join.slack.com/t/opctl/shared_invite/zt-51zodvjn-Ul_UXfkhqYLWZPQTvNPp5w)
 or
 [open an issue](https://github.com/opspec-pkgs/opencontainers.image.build/issues)
 
@@ -57,4 +53,4 @@ and [tagged](https://git-scm.com/book/en/v2/Git-Basics-Tagging); see
 # Contributing
 
 see
-[project/CONTRIBUTING.md](https://github.com/opspec-pkgs/project/blob/master/CONTRIBUTING.md)
+[project/CONTRIBUTING.md](https://github.com/opspec-pkgs/project/blob/main/CONTRIBUTING.md)

--- a/cmd.sh
+++ b/cmd.sh
@@ -9,10 +9,6 @@ buildctl-daemonless.sh \
   --frontend dockerfile.v0 \
   --local context=/buildContext \
   --local dockerfile=/ \
-  --output type=oci,dest=/image.tar \
+  --output type=oci,tar=false,dest=/image \
   --import-cache type=local,src=/cacheDir \
-  --export-cache type=local,dest=/cacheDir
-
-# @todo remove once https://github.com/moby/buildkit/issues/1219
-echo "untarring image"
-tar -xf /image.tar -C /image
+  --export-cache type=local,dest=/cacheDir,mode=max

--- a/op.yml
+++ b/op.yml
@@ -1,6 +1,5 @@
 description: Builds an open container initiative (OCI) image
 name: github.com/opspec-pkgs/opencontainers.image.build
-opspec: 0.1.6
 inputs:
   registryCreds:
     array:
@@ -51,4 +50,4 @@ run:
     envVars:
       registryCreds:
     image: { ref: moby/buildkit:master}
-version: 1.2.0
+version: 1.3.0


### PR DESCRIPTION
This PR leverages the new functionality of exporting the OCI Image Layout directly as opposed to tar'ing then untar'ing, which results in unnecessary cycles. 