### PR TITLE
Add support for multi-platform images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes will be documented in this file in accordance with
 
 ## \[2.0.0] - 2024-05-27
 
+### Added
+
+- Support for building multi-platform images via `platformsCsv` input
+
 ### Changed
 
 - Authentication configuration is now provided via `authConfig` (in the same format as dockers config.json) in order to ease usage for docker users.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ op:
   #   cacheDir: /default_cache
   #   context: /default_context
   #   contextIgnore: /default_context_ignore
+  #   platformsCsv: ""
   outputs:
     image:
 ```

--- a/op.yml
+++ b/op.yml
@@ -36,6 +36,14 @@ inputs:
   instructions:
     file:
       description: build instructions in the format of a Containerfile/Dockerfile
+  platformsCsv:
+    string:
+      default: ''
+      description: |
+        Platforms the image will be built for in the form of comma separated [platform specifiers](https://github.com/containerd/containerd/blob/8686ededfc90076914c5238eb96c883ea093a8ba/platforms/platforms.go#L63)
+        
+        e.g. 'linux/amd64,linux/arm64'
+
 outputs:
   image:
     dir:
@@ -61,6 +69,7 @@ run:
           --output type=oci,tar=false,dest=/image
           --import-cache type=local,src=/cacheDir
           --export-cache type=local,dest=/cacheDir,mode=max
+          --opt platform=$(platformsCsv)
       dirs:
         /buildContext: $(context)
         /cacheDir: $(cacheDir)


### PR DESCRIPTION
This PR adds support for building multi-platform images via the introduction of a `platformsCsv` input